### PR TITLE
Add unified _MACRO_MSG macro for all message types

### DIFF
--- a/src/evAssembler.py
+++ b/src/evAssembler.py
@@ -663,11 +663,43 @@ class MacroAssembler:
             evCmdType = textMacroMap[macro.cmdType]
             return self.processTextMacro(evCmdType, macro, commands, strTbl, tags)
 
+        if macro.cmdType == EvMacroType._MACRO_MSG:
+            return self.processUnifiedMacro(macro, commands, strTbl, tags)
+
         raise RuntimeError(
             "Invalid EvMacro: {} at {}:{}:{}".format(
                 macro, self.fileName, macro.line, macro.column
             )
         )
+
+    def processUnifiedMacro(self, macro, commands, strTbl, tags):
+        """Handle _MACRO_MSG('TYPE', 'bundle', 'label', 'text', ...) by dispatching to processTextMacro."""
+        if not macro.args:
+            raise RuntimeError("_MACRO_MSG is missing message type argument at {}:{}:{}".format(
+                self.fileName, macro.line, macro.column))
+
+        msgTypeArg = macro.args[0]
+        if msgTypeArg.argType != EvArgType.MacroString:
+            raise RuntimeError("_MACRO_MSG first argument must be a string type name at {}:{}:{}".format(
+                self.fileName, msgTypeArg.line, msgTypeArg.column))
+
+        unifiedTypeMap = {
+            '_TALKMSG': EvCmdType._TALKMSG,
+            '_TALK_KEYWAIT': EvCmdType._TALK_KEYWAIT,
+            '_EASY_OBJ_MSG': EvCmdType._EASY_OBJ_MSG,
+            '_EASY_BOARD_MSG': EvCmdType._EASY_BOARD_MSG,
+            '_ADD_CUSTUM_WIN_LABEL': EvCmdType._ADD_CUSTUM_WIN_LABEL,
+        }
+
+        evCmdType = unifiedTypeMap.get(msgTypeArg.data)
+        if evCmdType is None:
+            raise RuntimeError("Unknown message type '{}' in _MACRO_MSG at {}:{}:{}. Valid types: {}".format(
+                msgTypeArg.data, self.fileName, msgTypeArg.line, msgTypeArg.column,
+                ', '.join(unifiedTypeMap.keys())))
+
+        # Create a new macro with args shifted (skip the type arg)
+        shifted = EvMacro(macro.cmdType, macro.args[1:], macro.line, macro.column)
+        return self.processTextMacro(evCmdType, shifted, commands, strTbl, tags)
 
 class evAssembler(evListener):
     def __init__(self, fileName, commands=None, flags=None, works=None, sysflags=None):

--- a/src/ev_macro.py
+++ b/src/ev_macro.py
@@ -6,6 +6,7 @@ class EvMacroType(IntEnum):
     _MACRO_TALK_KEYWAIT = auto()
     _MACRO_EASY_OBJ_MSG = auto()
     _MACRO_ADD_CUSTUM_WIN_LABEL = auto()
+    _MACRO_MSG = auto()
 
     def isValid(self):
         return self != EvMacroType.Invalid


### PR DESCRIPTION
## Summary
- **`ev_macro.py`**: Added `_MACRO_MSG` to `EvMacroType` enum.
- **`evAssembler.py`**: Added `processUnifiedMacro()` method to `MacroAssembler` class. Dispatches `_MACRO_MSG('TYPE', 'bundle', 'label', 'text')` calls by extracting the type string, mapping to the corresponding `EvCmdType`, and delegating to `processTextMacro()`. Supports TALKMSG, TALK_KEYWAIT, EASY_OBJ_MSG, EASY_BOARD_MSG, and ADD_CUSTUM_WIN_LABEL. Old per-type macros still work (backward compatible).

## Test plan
- [ ] Assemble a `.ev` file using `_MACRO_MSG('TALKMSG', 'bundle', 'label', 'text')` — verify identical output to `_MACRO_TALKMSG('bundle', 'label', 'text')`
- [ ] Test each supported type string (TALKMSG, TALK_KEYWAIT, EASY_OBJ_MSG, EASY_BOARD_MSG, ADD_CUSTUM_WIN_LABEL)
- [ ] Test invalid type string — verify clear error message
- [ ] Verify existing `_MACRO_TALKMSG` etc. still work unchanged